### PR TITLE
make darwin (macos) compatible

### DIFF
--- a/internal/logger.go
+++ b/internal/logger.go
@@ -28,6 +28,6 @@ func NewLogger() logr.Logger {
 }
 
 func isTerminal() bool {
-	_, err := unix.IoctlGetTermios(int(os.Stdout.Fd()), unix.TCGETS)
+	_, err := unix.IoctlGetTermios(int(os.Stdout.Fd()), 0)
 	return err == nil
 }


### PR DESCRIPTION
fixes the "undefined: unix.TCGETS" error

TCGETS isn't defined in darwin, see https://golang.org/src/syscall/types_darwin.go